### PR TITLE
Fix +AlwaysOnTop at startup

### DIFF
--- a/CPU monitor/Drozd_CPU_monitor_simple.ahk
+++ b/CPU monitor/Drozd_CPU_monitor_simple.ahk
@@ -206,7 +206,7 @@ DllCall( "AnimateWindow", "Int", GuiHwnd, "Int", 200, "Int", 0x00000004 )
 OnMessage(0x201, "WM_LBUTTONDOWN") ; movable borderless window   
 OnMessage(0x404, "AHK_NOTIFYICON") ;click tray icon to show
 
-GoSub, onTop
+; GoSub, onTop
 GoSub, time_on
 GoSub, time_date
 GoSub, CPU_use


### PR DESCRIPTION
By default the window is created with +AlwaysOnTop activated, but when you call `GoSub, onTop` https://github.com/Drozdman-1/AHK-Scripts/blob/71bb72bcd8bf549a8cc0b9e6f9fa6af7ed938887/CPU%20monitor/Drozd_CPU_monitor_simple.ahk#L209 it actually disables it when the app launches. Disabling this line fixes this issue ;)
